### PR TITLE
Docker fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -145,6 +145,7 @@ setupDashboard()
     echo -e "[$GREEN+$RESET] Installing Docker.."
     sudo apt install -y docker.io;
     service docker start;
+    sudo systemctl enable docker;
     sleep 1;
     echo -e "[$GREEN+$RESET] Done."
 


### PR DESCRIPTION
Makes sure that docker is enabled to start on boot, otherwise users will experience problems when running the recon.sh script when their device has rebooted.

This enables docker to start at boot time.

Since this script expects the user has sudo access or is root, this change shouldn't cause any issues. 