### PR TITLE
httpx jsurl check before save

### DIFF
--- a/recon.sh
+++ b/recon.sh
@@ -212,7 +212,7 @@ fetchArchive() {
 
 	cat "$ARCHIVE"/getallurls.txt  | sort -u | unfurl --unique keys > "$ARCHIVE"/paramlist.txt
 
-	cat "$ARCHIVE"/getallurls.txt  | sort -u | grep -P "\w+\.js(\?|$)" | sort -u > "$ARCHIVE"/jsurls.txt
+	cat "$ARCHIVE"/getallurls.txt  | sort -u | grep -P "\w+\.js(\?|$)" | httpx -mc 200 | sort -u > "$ARCHIVE"/jsurls.txt
 
 	cat "$ARCHIVE"/getallurls.txt  | sort -u | grep -P "\w+\.php(\?|$) | sort -u " > "$ARCHIVE"/phpurls.txt
 


### PR DESCRIPTION
Save only valid js urls using httpx and piping alive urls into file. We want to feed only alive urls to linkfinder anyway otherwise it will produce some redundant output alongside with a useful.