### PR TITLE
No need to check if dir is already present or not

### DIFF
--- a/recon.sh
+++ b/recon.sh
@@ -45,12 +45,10 @@ __________                          __________.__
 	}
 
 checkDirectories() {
-	if [ ! -d "$RESULTDIR" ]; then
 		echo -e "[$GREEN+$RESET] Creating directories and grabbing wordlists for $GREEN$domain$RESET.."
 		mkdir -p "$RESULTDIR"
 		mkdir -p "$SUBS" "$SCREENSHOTS" "$DIRSCAN" "$HTML" "$WORDLIST" "$IPS" "$PORTSCAN" "$ARCHIVE" "$NUCLEISCAN"
 		#sudo mkdir -p /var/www/html/"$domain"
-	fi
 }
 
 startFunction() {


### PR DESCRIPTION
mkdir -p never removes/overwrite existing directory, removing if check as sometimes you need to manually run some tools and you are also maintaining same dir structure that ReconPi follows, then after the manual run, if you run ReconPi, it will not create other directories which you missed during manual enumeration and give you errors.

To avoid this condition, removing if check so that no matter what whenever ReconPi run on a particular domain, it tries to create dir structure and -p make sure that it does not overwrite any existing folder.